### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ skillkit is compatible with existings skills (SKILL.md), so you can browse and u
 
 ## Features
 
+[![Run in Smithery](https://smithery.ai/badge/skills/maxvaega)](https://smithery.ai/skills?ns=maxvaega&utm_source=github&utm_medium=badge)
+
+
 - **Fully compatible with existing skills**: existing skills can be copied directly, no change needed
 - **Framework-free**: can be used without any framework, or with other frameworks (currently only compatible with LangChain - more coming in the future!)
 - **Model-agnostic**: Works with any LLM


### PR DESCRIPTION
## Add skill discoverability badge

Your 28 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Agent Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/maxvaega)](https://smithery.ai/skills?ns=maxvaega&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.